### PR TITLE
Implement a mock API using local data as a fallback.

### DIFF
--- a/src/componentes/api/fetchItem.js
+++ b/src/componentes/api/fetchItem.js
@@ -1,13 +1,17 @@
+import { mockProducts } from './mock';
+
 // Função para buscar informações de um item específico
 export const fetchItem = async (itemId) => {
-  const response = await fetch(`https://api.mercadolibre.com/items/${itemId}`);
+  // Simula uma chamada de API
+  await new Promise(resolve => setTimeout(resolve, 500));
 
-  if (!response.ok) {
-    throw new Error('Erro ao buscar o item');
+  const product = mockProducts.find(item => item.id === itemId);
+
+  if (!product) {
+    throw new Error('Item não encontrado');
   }
 
-  const data = await response.json();
-  return data;
+  return product;
 };
 
 export default fetchItem;

--- a/src/componentes/api/fetchProducts.js
+++ b/src/componentes/api/fetchProducts.js
@@ -1,12 +1,19 @@
+import { mockProducts } from './mock';
+
 //Busca produtos com base em uma consulta.
 const fetchProducts = async (query) => {
-  const response = await fetch(`https://api.mercadolibre.com/sites/MLB/search?q=${query}`);
+  // Simula uma chamada de API
+  await new Promise(resolve => setTimeout(resolve, 500));
 
-  if (!response.ok) {
-    throw new Error('Erro ao buscar produtos');
+  if (!query) {
+    return mockProducts;
   }
 
-  const data = await response.json();
-  return data.results;
+  const lowercasedQuery = query.toLowerCase();
+  const results = mockProducts.filter(product =>
+    product.title.toLowerCase().includes(lowercasedQuery)
+  );
+
+  return results;
 };
 export default fetchProducts;

--- a/src/componentes/api/mock.js
+++ b/src/componentes/api/mock.js
@@ -1,0 +1,46 @@
+export const mockProducts = [
+  {
+    id: 'MLB1',
+    title: 'Produto Fictício 1',
+    price: 100.00,
+    thumbnail: 'https://http2.mlstatic.com/D_NQ_NP_2X_787280-MLB53603953381_022023-F.webp',
+    pictures: [
+        {
+            url: 'https://http2.mlstatic.com/D_NQ_NP_2X_787280-MLB53603953381_022023-F.webp'
+        }
+    ]
+  },
+  {
+    id: 'MLB2',
+    title: 'Produto Fictício 2',
+    price: 250.50,
+    thumbnail: 'https://http2.mlstatic.com/D_NQ_NP_2X_968521-MLB43888301358_102020-F.webp',
+     pictures: [
+        {
+            url: 'https://http2.mlstatic.com/D_NQ_NP_2X_968521-MLB43888301358_102020-F.webp'
+        }
+    ]
+  },
+  {
+    id: 'MLB3',
+    title: 'Produto Fictício 3 - Um item com um nome um pouco mais longo',
+    price: 99.99,
+    thumbnail: 'https://http2.mlstatic.com/D_NQ_NP_2X_968521-MLB43888301358_102020-F.webp',
+     pictures: [
+        {
+            url: 'https://http2.mlstatic.com/D_NQ_NP_2X_968521-MLB43888301358_102020-F.webp'
+        }
+    ]
+  },
+    {
+    id: 'MLB4',
+    title: 'Produto Fictício 4',
+    price: 12.00,
+    thumbnail: 'https://http2.mlstatic.com/D_NQ_NP_2X_787280-MLB53603953381_022023-F.webp',
+     pictures: [
+        {
+            url: 'https://http2.mlstatic.com/D_NQ_NP_2X_787280-MLB53603953381_022023-F.webp'
+        }
+    ]
+  },
+];


### PR DESCRIPTION
When the external Mercado Livre API is unavailable or causing deployment issues, this change allows the application to run locally using a set of fictitious products.

- Created `src/componentes/api/mock.js` with sample product data.
- Modified `fetchProducts.js` to search through the mock data.
- Modified `fetchItem.js` to retrieve a single item from the mock data.